### PR TITLE
Created amiibo report endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,20 +28,11 @@ core.AmiiboDatabase
   .then(() => {
     core.System
       .on('error', log.error)
-      .on('reader', message => {
-        log.info('reader', message);
-        core.Websockets.publish('reader', message);
-      })
-      .on('purpose', purpose => {
-        core.Websockets.publish('purpose', purpose);
-      })
-      .on('write-progress', message => {
-        log.info(`write progress: ${message}`);
-        core.Websockets.publish('write-progress', message);
-      })
+      .on('reader', message => core.Websockets.publish('reader', message))
+      .on('purpose', purpose => core.Websockets.publish('purpose', purpose))
+      .on('write-progress', message => core.Websockets.publish('write-progress', message))
       .on('card', ({present, blank}) => core.Websockets.publish('card', {present, blank}))
       .on('amiibo', (amiiboId, amiiboCharacterName, amiibo) => {
-        log.info('amiibo', amiiboId);
         amiibo.imageUrl()
           .then(imageUrl => {
             core.Websockets.publish('card', {present: true, blank: false});
@@ -53,7 +44,6 @@ core.AmiiboDatabase
           .catch(log.error);
       })
       .on('amiibo.removed', () => {
-        log.info('amiibo removed');
         core.Websockets.publish('card', {present: false});
         core.Websockets.publish('amiibo', null);
         core.Websockets.publish('write-progress', 'card removed');

--- a/core/Amiibo.js
+++ b/core/Amiibo.js
@@ -1,6 +1,7 @@
 'use strict';
 const amiitool = require('./Amiitool'),
   NTAG215 = require('./NTAG215');
+const { times } = require('lodash');
 
 class Amiibo extends NTAG215 {
   HEAD_BLOCK_NUMBER = 0x15;
@@ -44,13 +45,21 @@ class Amiibo extends NTAG215 {
     return `https://raw.githubusercontent.com/N3evin/AmiiboAPI/master/images/icon_${head.toString(16).padStart(8, '0')}-${tail.toString(16).padStart(8, '0')}.png`;
   }
 
-  async validateBlankTag() {
-    console.log('validating tag is blank');
+  async hasAmiiboLock() {
     const lockBytes = await this.lockBytes();
-    if (lockBytes[0] === 0x0f && lockBytes[1] === 0xe0) {
-      throw new Error('tag is already an Amiibo');
+    return lockBytes[0] === 0x0f && lockBytes[1] === 0xe0;
+  }
+
+  async blankTag() {
+    const isLocked = await this.hasAmiiboLock();
+    return !isLocked;
+  }
+
+  async validateBlankTag() {
+    if (await this.blankTag()) {
+      return;
     }
-    console.log('tag is blank');
+    throw new Error('tag is already an Amiibo');
   }
 
   async writeUserMemory(amiiboData) {

--- a/core/AmiiboDataReport/blank.js
+++ b/core/AmiiboDataReport/blank.js
@@ -1,0 +1,19 @@
+'use strict';
+const BufferTagReader = require('../BufferTagReader'),
+  Amiibo = require('../Amiibo');
+
+exports = module.exports = data => {
+  const reader = new BufferTagReader(data);
+  const amiibo = new Amiibo(reader);
+  return amiibo.blankTag()
+    .then(isBlank => ({
+      ok: true,
+      value: isBlank,
+      error: null,
+    }))
+    .catch(err => ({
+      ok: false,
+      value: null,
+      error: err.message,
+    }));
+};

--- a/core/AmiiboDataReport/generate.js
+++ b/core/AmiiboDataReport/generate.js
@@ -1,0 +1,16 @@
+'use strict';
+const id = require('./id'),
+  imageUrl = require('./imageUrl'),
+  name = require('./name'),
+  size = require('./size'),
+  blank = require('./blank');
+
+exports = module.exports = amiiboData => Promise
+  .all([id, imageUrl, name, size, blank].map(report => report(amiiboData)))
+  .then(([idReport, imageUrlReport, nameReport, sizeReport, blankReport]) => ({
+    id: idReport,
+    size: sizeReport,
+    imageUrl: imageUrlReport,
+    name: nameReport,
+    blank: blankReport,
+  }));

--- a/core/AmiiboDataReport/id.js
+++ b/core/AmiiboDataReport/id.js
@@ -1,0 +1,19 @@
+'use strict';
+const BufferTagReader = require('../BufferTagReader'),
+  Amiibo = require('../Amiibo');
+
+exports = module.exports = data => {
+  const reader = new BufferTagReader(data);
+  const amiibo = new Amiibo(reader);
+  return amiibo.id()
+    .then(amiiboId => ({
+      ok: true,
+      value: amiiboId,
+      error: null,
+    }))
+    .catch(err => ({
+      ok: false,
+      value: null,
+      error: err.message,
+    }));
+};

--- a/core/AmiiboDataReport/imageUrl.js
+++ b/core/AmiiboDataReport/imageUrl.js
@@ -1,0 +1,19 @@
+'use strict';
+const BufferTagReader = require('../BufferTagReader'),
+  Amiibo = require('../Amiibo');
+
+exports = module.exports = data => {
+  const reader = new BufferTagReader(data);
+  const amiibo = new Amiibo(reader);
+  return amiibo.imageUrl()
+    .then(imageUrl => ({
+      ok: true,
+      value: imageUrl,
+      error: null,
+    }))
+    .catch(err => ({
+      ok: false,
+      value: null,
+      error: err.message,
+    }));
+};

--- a/core/AmiiboDataReport/index.js
+++ b/core/AmiiboDataReport/index.js
@@ -1,0 +1,11 @@
+'use strict';
+exports = module.exports = {};
+const fs = require('fs'),
+  path = require('path');
+
+fs.readdirSync(__dirname)
+  .filter(fname => path.basename(__filename) !== fname)
+  .map(fname => path.basename(fname, '.js'))
+  .forEach(fname => {
+    exports[fname] = require(`./${fname}`);
+  });

--- a/core/AmiiboDataReport/name.js
+++ b/core/AmiiboDataReport/name.js
@@ -1,0 +1,21 @@
+'use strict';
+const BufferTagReader = require('../BufferTagReader'),
+  Amiibo = require('../Amiibo'),
+  AmiiboDatabase = require('../AmiiboDatabase');
+
+exports = module.exports = data => {
+  const reader = new BufferTagReader(data);
+  const amiibo = new Amiibo(reader);
+  return amiibo.id()
+    .then(amiiboId => AmiiboDatabase.lookupById(amiiboId))
+    .then(amiiboCharacter => ({
+      ok: true,
+      value: amiiboCharacter.name,
+      error: null,
+    }))
+    .catch(err => ({
+      ok: false,
+      value: null,
+      error: err.message,
+    }));
+};

--- a/core/AmiiboDataReport/size.js
+++ b/core/AmiiboDataReport/size.js
@@ -1,0 +1,8 @@
+'use strict';
+const _ = require('lodash');
+
+exports = module.exports = data => Promise.resolve({
+  ok: _.size(data) === 540,
+  value: _.size(data),
+  error: _.size(data) === 540 ? '' : `file size should be 540 bytes; got ${_.size(data)} instead`,
+});

--- a/routes/amiiboReport.js
+++ b/routes/amiiboReport.js
@@ -1,0 +1,13 @@
+'use strict';
+const _ = require('lodash'),
+  HttpError = require('http-error-constructor'),
+  core = require('../core');
+
+exports = module.exports = (req, res, next) => {
+  if (!req.file) {
+    return Promise.resolve(next(new HttpError(400, 'missing file')));
+  }
+  return core.AmiiboDataReport.generate(req.file.buffer)
+    .then(report => res.json(report))
+    .catch(next);
+};

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,6 +7,7 @@ const multer = require('multer'),
   setAmiibo = require('./setAmiibo'),
   importAmiibo = require('./importAmiibo'),
   writeAmiibo = require('./writeAmiibo'),
+  amiiboReport = require('./amiiboReport'),
   setPurpose = require('./setPurpose');
 
 const amiiboUpload = multer({
@@ -16,6 +17,7 @@ const amiiboUpload = multer({
 
 exports.get('/health', (req, res) => res.sendStatus(200));
 exports.get('/amiibo', amiibo);
+exports.post('/amiibo/report', amiiboUpload.single('file'), amiiboReport);
 exports.get('/amiibos', amiibos);
 exports.post('/amiibos', amiiboUpload.single('file'), importAmiibo);
 exports.post('/amiibo', writeAmiibo);


### PR DESCRIPTION
Fixes #11

POST /api/amiibo/report

Include Amiibo data under `file` field.

Example:
```
curl -s -F 'file=@Lucky.bin' 'http://amiibo/api/amiibo/report' | python -m json.tool
{
    "blank": {
        "error": null,
        "ok": true,
        "value": false
    },
    "id": {
        "error": null,
        "ok": true,
        "value": "02ec000101c40502"
    },
    "imageUrl": {
        "error": null,
        "ok": true,
        "value": "https://raw.githubusercontent.com/N3evin/AmiiboAPI/master/images/icon_02ec0001-01c40502.png"
    },
    "name": {
        "error": null,
        "ok": true,
        "value": "Lucky"
    },
    "size": {
        "error": "",
        "ok": true,
        "value": 540
    }
}
```